### PR TITLE
Add option to exclude import statements for some types

### DIFF
--- a/integration/graphql-codegen.yml
+++ b/integration/graphql-codegen.yml
@@ -5,7 +5,9 @@ generates:
   integration/graphql-types.ts:
     config:
       possibleTypes:
-        generateUnionTypes: true
-        entityImportPattern: "./entities#[ENTITY]"
+        unionTypes:
+          generate: true
+          entityImportPattern: "./entities#[ENTITY]"
+          ignore: ["DoNotGenUnion", "IgnoreMeInUnions"]
     plugins:
       - ./build/index.js

--- a/integration/graphql-types.ts
+++ b/integration/graphql-types.ts
@@ -1,7 +1,8 @@
 import { Author, Book } from "./entities";
 
 export const possibleTypes = {
-  HasName: ["Author", "Book"],
+  HasName: ["Author", "Book", "IgnoreMeInUnions"],
+  DoNotGenUnion: ["Book", "IgnoreMeInUnions"],
 };
 
 export type HasNameTypes = Author | Book;

--- a/integration/schema.graphql
+++ b/integration/schema.graphql
@@ -2,10 +2,20 @@ type Author implements HasName {
   name: String!
 }
 
-type Book implements HasName {
+type Book implements HasName & DoNotGenUnion {
   name: String!
+  someField: String!
 }
 
 interface HasName {
   name: String!
+}
+
+type IgnoreMeInUnions implements HasName & DoNotGenUnion {
+  name: String!
+  someField: String!
+}
+
+interface DoNotGenUnion {
+  someField: String!
 }


### PR DESCRIPTION
Turns out we did have one interface which wasn't related to our entities. Adding a config option to not generate import statements for those types.