### PR TITLE
Make the possibleTypes variable a const to be able to pull out a type from the values

### DIFF
--- a/integration/graphql-types.ts
+++ b/integration/graphql-types.ts
@@ -1,3 +1,3 @@
 export const possibleTypes = {
   HasName: ["Author", "Book"],
-};
+} as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
+import { PluginFunction, Types } from "@graphql-codegen/plugin-helpers";
 import { GraphQLObjectType } from "graphql";
 import { code } from "ts-poet";
-import { PluginFunction, Types } from "@graphql-codegen/plugin-helpers";
 import PluginOutput = Types.PluginOutput;
 
 /** Generates a `possibleTypes` config object for apollo. */
@@ -23,7 +23,7 @@ export const plugin: PluginFunction<{}> = async schema => {
       ${Object.entries(interfaceImpls).map(([name, impls]) => {
         return `${name}: [${impls.map(n => `"${n}"`).join(", ")}],`;
       })}
-    };
+    } as const;
   `.toStringWithImports();
   return { content } as PluginOutput;
 };


### PR DESCRIPTION
This allows you to do something like...

```
type NamedTypes = typeof possibleTypes.Named[number];
// Evaluates to "Author" | "Book"
```